### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/seita1996/react-router-endpoint-diff/security/code-scanning/3](https://github.com/seita1996/react-router-endpoint-diff/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify `contents: read`, which is sufficient for the workflow's operations, as it only needs to read the repository's contents to build, lint, and test the code. No write permissions are required for the steps in this workflow.

The `permissions` block will be added immediately after the `name` field at the top of the file to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
